### PR TITLE
update CMakeLists.txt to set CPM_SOURCE_CACHE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# bitchat
+/*.pem
+/*.log
+/peers_keys.txt
+/temp
+/data
+dependencies/
+
 # os
 Thumbs.db
 .DS_Store
@@ -46,10 +54,3 @@ build_*/
 *.egg-info
 .pytest_cache
 poetry.lock
-
-# bitchat
-/*.pem
-/*.log
-/peers_keys.txt
-/temp
-/data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 # Include CPM for dependency management
 include(cmake/CPM.cmake)
+set(CPM_SOURCE_CACHE "${CMAKE_SOURCE_DIR}/dependencies")
+
 
 # Include custom functions
 include(cmake/functions.cmake)


### PR DESCRIPTION
I find my self `rm -rf build` often and it takes time to re-sync deps so this should be faster.

BTW- what is the use of vendor/? why dont we just add noise-c via CPM? also uuidv4 is so basic perhaps hard-path it in dependencies or have a `bitchat/utils`.

will try to contribute more,i purchased two RPI pico 2W to prototype with, the Zephyr project uses `arch/` & `soc/` not sure how we will add support for all of this, i'm currently working on integrating arm/riscv compiler's.